### PR TITLE
Fix an FK issue when batch_size = 3

### DIFF
--- a/PyTorch/utils/nn_transforms.py
+++ b/PyTorch/utils/nn_transforms.py
@@ -229,9 +229,9 @@ def repr6d2mat(repr):
     x = repr[..., :3]
     y = repr[..., 3:]
     x = x / x.norm(dim=-1, keepdim=True)
-    z = torch.cross(x, y)
+    z = torch.linalg.cross(x, y)
     z = z / z.norm(dim=-1, keepdim=True)
-    y = torch.cross(z, x)
+    y = torch.linalg.cross(z, x)
     res = [x, y, z]
     res = [v.unsqueeze(-2) for v in res]
     mat = torch.cat(res, dim=-2)
@@ -242,9 +242,9 @@ def repr6d2quat(repr) -> torch.Tensor:
     x = repr[..., :3]
     y = repr[..., 3:]
     x = x / x.norm(dim=-1, keepdim=True)
-    z = torch.cross(x, y)
+    z = torch.linalg.cross(x, y)
     z = z / z.norm(dim=-1, keepdim=True)
-    y = torch.cross(z, x)
+    y = torch.linalg.cross(z, x)
     res = [x, y, z]
     res = [v.unsqueeze(-2) for v in res]
     mat = torch.cat(res, dim=-2)


### PR DESCRIPTION
Replace torch.cross() with torch.linalg.cross() to avoid unexpected behavior when an expected dimension has size 3.